### PR TITLE
fix: add binaryTragets fix for docker deployment on M1

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,7 +2,8 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-1.1.x"]
 }
 
 datasource db {


### PR DESCRIPTION
some prisma error occurs when running the server on linux docker container on M1 host