### PR TITLE
chore: specify mainnet .env vars

### DIFF
--- a/.env
+++ b/.env
@@ -7,18 +7,28 @@ POSTGRES_HOST_ADDRESS=localhost
 
 DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST_ADDRESS}:${POSTGRES_HOST_PORT}/${POSTGRES_DB}?schema=${POSTGRES_SCHEMA}
 
+AUTH_TOKEN=774a64fdc5dc8d5b9dd579bb9e6f556baaecd90610667c69db64dbc0a8667af1
+
+# if SUBSCRIBE_TO_ALL_TXS is omitted or has 0 value it will subscribe only to ROUTER_ADDRESS
+SUBSCRIBE_TO_ALL_TXS=1
+
+# set MDW_PING_TIMOUT_MS to 0 or undefined for indefinite ping timeout on mdw websocket
+MDW_PING_TIMEOUT_MS=10000
+
+#For testnet
 NETWORK_NAME=testnet
 ROUTER_ADDRESS=ct_MLXQEP12MBn99HL6WDaiTqDbG4bJQ3Q9Bzr57oLfvEkghvpFb
 FACTORY_ADDRESS=ct_NhbxN8wg8NLkGuzwRNDQhMDKSKBwDAQgxQawK7tkigi2aC7i9
-SUBSCRIBE_TO_ALL_TXS=1
-
-AUTH_TOKEN=774a64fdc5dc8d5b9dd579bb9e6f556baaecd90610667c69db64dbc0a8667af1
-
 # these are contract addresses for swagger examples and can be omitted
 DOC_PAIR=ct_2JZNDfAQHZMfoBuh32Aijd9TR8A5SHUVBzxC6x5d4sS7o8xeqN
 DOC_TOKEN1=ct_b7FZHQzBcAW4r43ECWpV3qQJMQJp5BxkZUGNKrqqLyjVRN3SC
 DOC_TOKEN2=ct_JDp175ruWd7mQggeHewSLS1PFXt9AzThCDaFedxon8mF8xTRF
 
-# set MDW_PING_TIMOUT_MS to 0 or undefined for indefinite ping timeout on mdw websocket
-MDW_PING_TIMEOUT_MS=10000
-
+#For mainnet
+#NETWORK_NAME=mainnet
+#ROUTER_ADDRESS=ct_azbNZ1XrPjXfqBqbAh1ffLNTQ1sbnuUDFvJrXjYz7JQA1saQ3
+#FACTORY_ADDRESS=ct_2mfj3FoZxnhkSw5RZMcP8BfPoB1QR4QiYGNCdkAvLZ1zfF6paW
+## these are contract addresses for swagger examples and can be omitted
+#DOC_PAIR=ct_NNmdSt3Ws4r87pESGKrhGb7VJmC8zpZymXNJKHY8bTLaFttsi
+#DOC_TOKEN1=ct_2dE7Xd7XCg3cwpKWP18VPDwfhz5Miji9FoKMTZN7TYvGt64Kc
+#DOC_TOKEN2=ct_7ur9ypT3a4tjxxv5iG6zEQDQhysNtCKr6tyc7PkqhtRmEw6yY


### PR DESCRIPTION
we need also an example of some .env var for `mainnet` deployment contract